### PR TITLE
Use 2016 version of CI build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 
 install:
     - sudo apt-get install -y frc-toolchain
-    - git clone https://github.com/intimitrons4604/tools-ci-cpp-build-script.git ~/tools-ci-cpp-build-script
+    - git clone --branch 2016.1.0 --depth 1 https://github.com/intimitrons4604/tools-ci-cpp-build-script.git ~/tools-ci-cpp-build-script
 
 script:
     - cd ~/tools-ci-cpp-build-script


### PR DESCRIPTION
For 2017, the build script had to be changed to use the new WPILib artifact structure. The structure is not backwards compatible. This code does build with the 2017 libraries, but will be fixed to the 2016 version of the build script for future consistency.

- Clone directly to required tag
- Shallow clone - only pull commit tag is pointing to

Cloned from intimitrons4604/stella-cpp-sample-robot#6